### PR TITLE
[`build`] Support fips-compliant build

### DIFF
--- a/hack/is_fips_compliant.sh
+++ b/hack/is_fips_compliant.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+# Check if a file name is given as an argument
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <binary-file>"
+    exit 1
+fi
+
+# Run go tool nm on the provided file and capture the output
+nm_output=$(go tool nm "$1")
+
+# Check for the presence of symbols
+if echo "$nm_output" | grep -q 'sig.StandardCrypto'; then
+    echo "$1 contains sig.StandardCrypto, which is NOT OK."
+    exit 1
+else
+    if echo "$nm_output" | grep -qE 'sig.FIPSOnly|sig.BoringCrypto'; then
+        echo "$1 contains sig.FIPSOnly or sig.BoringCrypto, which is OK."
+    else
+        echo "$1 does not contain sig.StandardCrypto, sig.FIPSOnly, or sig.BoringCrypto, which is OK."
+    fi
+fi


### PR DESCRIPTION
The `Dockerfile` can now build an image with `CGO_ENABLED=1` and `GOEXPERIMENT=boringcrypto`

The "backwards functionality" to build an image that is not fips compliant still works.